### PR TITLE
Fixed url chrome webstore

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Chrometana
 
 A Windows 10 Reaction project written in 4 hours
 
-[Link to install on Chrome Web Store](https://chrome.google.com/webstore/detail/kaicbfmipfpfpjmlbpejaoaflfdnabnc/publish-accepted)
+[Link to install on Chrome Web Store](https://chrome.google.com/webstore/detail/kaicbfmipfpfpjmlbpejaoaflfdnabnc)
 
 INTRODUCTION
 ------------


### PR DESCRIPTION
Url for chrome webstore was showing the 'extension published page' instead of the normal extension page. This was causing the install button to be disabled.