### PR TITLE
Fix if chrome is not allowed to run in the background

### DIFF
--- a/js/bootstrap.js
+++ b/js/bootstrap.js
@@ -1,35 +1,39 @@
-var storageChange="Google.com"
+var storageChange="Google.com";
+function convertURL(url){
+    if(storageChange=="Google.com"){
+        return url.replace("www.bing.com/search", "www.google.com/search");
+    }
+    if(storageChange=="DuckDuckGo.com"){
+        return url.replace("www.bing.com/search", "www.duckduckgo.com");
+    }
+    if(storageChange=="Ask.com"){
+        return url.replace(/.*:\/\/www.bing.com\/search/, "http://www.ask.com/web");
+    }
+    if(storageChange=="Yahoo.com"){
+        return url.replace("www.bing.com/search?q", "search.yahoo.com/search?p");
+    }
+    if(storageChange=="Aol.com"){
+        return url.replace(/.*:\/\/www.bing.com\/search/, "http://search.aol.com/aol/search");
+    }
+    if(storageChange=="Wow.com"){
+        return url.replace(/.*:\/\/www.bing.com/, "http://us.wow.com");
+    }
+    return url.replace("www.bing.com/search", "www.google.com/search");
+}
 chrome.storage.sync.get('search_engine', function (obj) {
         console.log('myKey', obj);
-        storageChange=obj['search_engine']
+        storageChange=obj['search_engine'];
 });
 
 chrome.storage.onChanged.addListener(function(changes, namespace) {  
     storageChange = changes['search_engine']['newValue'];
-    console.log(storageChange)
+    console.log(storageChange);
 });
 
 chrome.webRequest.onBeforeRequest.addListener(function(details) {
-   	console.log(storageChange)
-    if(storageChange=="Google.com"){
-    	return { redirectUrl: details.url.replace("www.bing.com/search", "www.google.com/search")};
-    }
-    if(storageChange=="DuckDuckGo.com"){
-    	return { redirectUrl: details.url.replace("www.bing.com/search", "www.duckduckgo.com")};
-    }
-    if(storageChange=="Ask.com"){
-    	return { redirectUrl: details.url.replace(/.*:\/\/www.bing.com\/search/, "http://www.ask.com/web")};
-    }
-    if(storageChange=="Yahoo.com"){
-    	return { redirectUrl: details.url.replace("www.bing.com/search?q", "search.yahoo.com/search?p")};
-    }
-    if(storageChange=="Aol.com"){
-    	return { redirectUrl: details.url.replace(/.*:\/\/www.bing.com\/search/, "http://search.aol.com/aol/search")};
-    }
-    if(storageChange=="Wow.com"){
-    	return { redirectUrl: details.url.replace(/.*:\/\/www.bing.com/, "http://us.wow.com")};
-    }
-    return { redirectUrl: details.url.replace("www.bing.com/search", "www.google.com/search")};
+   	console.log(storageChange);
+    
+    return { redirectUrl: convertURL(details.url)};
 }, {urls: ["*://www.bing.com/search*"]}, ["blocking"]);
 
 // Redirect to welcome.html on install
@@ -41,3 +45,17 @@ chrome.runtime.onInstalled.addListener(function(details){
         console.log("Updated from " + details.previousVersion + " to " + thisVersion + "!");
     }
 });
+// Call the above function when the url of a tab changes.
+chrome.tabs.onUpdated.addListener(startUpRedirect);
+
+// Show page action icon in omnibar.
+function startUpRedirect( tabId, changeInfo, tab ) {
+    console.log(tab);
+    var pattern = /www.bing.com\/search+/gi;
+    if(tab['url'].match(pattern)){
+        chrome.tabs.getSelected(null, function(tab){
+            chrome.tabs.update(tab.id, {url: convertURL(tab.url)});
+        });
+    }
+    
+};

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,8 @@
         "webRequest",
         "webRequestBlocking",
         "storage",
-        "background"
+        "background",
+        "tabs"
   ],
   "background": {
     "scripts": ["js/bootstrap.js"]


### PR DESCRIPTION
If Chrome is not allowed to "Continue running background apps when Google Chrome is closed" (chrome://settings/->Show advanced settings->System), Chrometana was not redirecting from Bing to the preferred search engine.