### PR TITLE
Use class list opposed to using the classname string

### DIFF
--- a/Chrometana/js/options.js
+++ b/Chrometana/js/options.js
@@ -147,13 +147,11 @@ function getURLVariable(variable){
 }
 
 function addClass(element, classNameToAdd) {
-  if (!element.className.includes(classNameToAdd)) {
-    element.className = element.className + ' ' + classNameToAdd;
-  }
+  element.classList.add(classNameToAdd);
 }
 
-function removeClass(element, classNameToAdd) {
-  element.className = element.className.replace(classNameToAdd, '');
+function removeClass(element, classNameToRemove) {
+  element.classList.remove(classNameToRemove);
 }
 
 String.prototype.contains = function(text) {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1644131/11522259/934f0682-9883-11e5-8b52-bd1e9b131a65.png)
This is caused because the add is adding a space that is not being trimmed.  Opposed to using classname (String), it is better to use classlist (List Object).

http://www.w3schools.com/jsref/prop_element_classlist.asp

|     |       |
|---------|---------------------------------------------------------------------------------------------------------------------|
| .remove | Removes one or more class names from an element.Note: Removing a class that does not exist, does NOT throw an error |
| .add    | Adds one or more class names to an element.If the specified class already exist, the class will not be added        |