### PR TITLE
Fixed radio buttons & text-edit cursor appearing on non-editable text.

### DIFF
--- a/Chrometana/html/css/style.css
+++ b/Chrometana/html/css/style.css
@@ -2,7 +2,7 @@ body {
     background-color: #FFFFFF;
     color: #fff;
     font-family: 'Raleway',Tahoma,Verdana,Arial,sans-serif;
-
+	cursor: default;
 }
 
 .content {

--- a/Chrometana/html/options.html
+++ b/Chrometana/html/options.html
@@ -60,18 +60,18 @@
 							<div class="form-group">
 									<input type="checkbox" id="enable_open_website" class="chrometana_advanced_setting" /><label for="enable_open_website" class="pointer">Enable "Open Website"</label>
 									<div class="helper-text">
-										<p>Enable abilty to search "Open example.com" and load example.com</p>
+										<p>Enable ability to search "Open example.com" and load example.com</p>
 									</div>
 									<br>
 								</div>							
 							</section>
 							<section class="col-md-6 col-sm-6 col-lg-6">
 								<div>
-									<label for="all_bing_searches" class="pointer checkbox-inline option-text"><input type="checkbox" id="all_bing_searches" class="chrometana_advanced_setting">Apply to all Bing Searches</label>
+									<label for="all_bing_searches" class="pointer checkbox-inline option-text"><input type="radio" name="search_option" value="all_searches" id="all_bing_searches" class="chrometana_advanced_setting">Apply to all Bing Searches</label>
 									<div class="helper-text">
 										<p>Redirect all searches sent to bing (including Cortana)</p>
 									</div>
-									<label for="exclude_settings_app" class="option-text pointer checkbox-inline"><input type="checkbox" id="exclude_settings_app" class="chrometana_advanced_setting">Apply Only to Cortana Searches</label>
+									<label for="exclude_settings_app" class="option-text pointer checkbox-inline"><input type="radio" name="search_option" value="cortana_searches" id="exclude_settings_app" class="chrometana_advanced_setting">Apply Only to Cortana Searches</label>
 									<div class="helper-text">
 										<p>Only redirect searches that come from Cortana</p>
 									</div>
@@ -95,7 +95,6 @@
 					</div>
 				</div>
 			</div>
-		</div>	
 		<script src="../js/options.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
I set them to be radio buttons rather than checkboxes and game them each the same 'name' attribute (to put them in a radio group), and a 'value' attribute (which, judging from options.js, you don't have to use). You can now only select one of them at a time.

I also noticed the helper text labels had the editable-text cursor over them instead of the expected default cursor, so I added a line to the body{} section of the CSS to make sure it's always the default unless overridden by another class.

Hope that helps!