### PR TITLE
Fix "page not found" after searching on Bing

### DIFF
--- a/background/bootstrap.js
+++ b/background/bootstrap.js
@@ -138,7 +138,7 @@
 
   // Fallback when Chrome is not already running
   chrome.runtime.onMessage.addListener(onMessage);
-  function onMessage(request, callback) {
+  function onMessage(request, sender, callback) {
     if (request.action === "convertURL") {
       callback(convertURL(request.url));
     }


### PR DESCRIPTION
I could reproduce #46 and I noticed that when the error happened, the extension logged an error like:  
`Error in event handler: TypeError: callback is not a function`

So I looked up the documentation for [`chrome.runtime.onMessage.addListener`](https://developer.chrome.com/docs/extensions/reference/runtime/#event-onMessage) and the callback is actually the 3rd parameter, not the 2nd. So changing that fixed the problem for me.

Should fix #46 